### PR TITLE
Yarn installation problem has solved

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,9 @@
     "typescript": "3.2.2",
     "vscode": "^1.1.17"
   },
+  "resolutions": {
+    "@types/react": "16.7.18"
+  },
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
Hello guys,

I've encountered an odd problem when I was installing dependency packages using `Yarn` and `Yarn install` command. Typescript couldn't compile the codes properly and it threw this exception on running `build` script:

![builderror](https://user-images.githubusercontent.com/13152108/51567797-5d007f80-1ead-11e9-9187-b70fdfc45162.PNG)

The problem caused by Yarn that was resolving multiple versions of `@types/react` package. The result can be observed in the `yarn.lock` file and like this:

![duplicatelock](https://user-images.githubusercontent.com/13152108/51568107-30009c80-1eae-11e9-82a3-fd8f997f5e4c.PNG)

I solved my problem simply by adding a resolutions property to the package.json file. I've thought that would be resonable to add it directly as a pull request.

Note: There is a problem with upgrading packages and the the inconsistency problem can occur again after upgrading the main dependency (`@types/react`). To prevent that problem the resolutions property should be edited manually in that situation! However, there is already an open issue about this problem. Related topic at the Yarn repo:
https://github.com/yarnpkg/yarn/issues/5413
