### PR TITLE
Add Chrome Headless links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <h4 align="center">A real browser preview inside your editor that you can debug.</h4>
 
-Browser Preview for VS Code enables you to open a real browser preview inside your editor that you can debug. Browser Preview is powered by Chrome Headless, and works by starting a headless Chrome instance in a new process. This enables a secure way to render web content inside VS Code, and enables interesting features such as in-editor debugging and more!
+Browser Preview for VS Code enables you to open a real browser preview inside your editor that you can debug. Browser Preview is powered by [Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome), and works by starting a headless Chrome instance in a new process. This enables a secure way to render web content inside VS Code, and enables interesting features such as in-editor debugging and more!
 
 ![](resources/demo.gif)
 
@@ -22,7 +22,7 @@ Make sure you have Google Chrome installed on your computer.
 
 ## Features
 
-- Browser preview inside VS Code (Powered by Chrome Headless).
+- Browser preview inside VS Code (Powered by [Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome)).
 - Ability to have multiple previews open at the same time.
 - Debuggable. Launch urls and attach [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) to the browser view instance, and debug within VS Code.
 - Attach Chrome DevTools via `chrome://inspect`


### PR DESCRIPTION
This PR just adds links to [Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome) on `README.md` file. Particularly useful for newcomers (like me) interested about this. As well as other projects do it. For instance [Puppeteer](https://github.com/GoogleChrome/puppeteer#puppeteer).