### PR TITLE
Ignore cert errors

### DIFF
--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -22,7 +22,7 @@ export default class Browser extends EventEmitter {
 
     this.browser = await puppeteer.launch({
       executablePath: chromePath,
-      args: ['--remote-debugging-port=9222']
+      args: ['--remote-debugging-port=9222', '--ignore-certificate-errors']
     });
   }
 


### PR DESCRIPTION
This fixes my initial issue from #34. It does not add the extra jargle in that issue.

It should also be noted that with this change you should never try to hit any site you wish to be secure on. Such as you should not log into Amazon with it. I don't think that would be an issue. But people are unwise sometimes.