### PR TITLE
Remove the hardcoded chunk script

### DIFF
--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -298,18 +298,26 @@ class BrowserViewWindow extends EventEmitter.EventEmitter2 {
     const mainScript = manifest['main.js'];
     const mainStyle = manifest['main.css'];
     const runtimeScript = manifest['runtime~main.js'];
-    const chunkScript = manifest['static/js/1.0e8ab1f0.chunk.js'];
+
+    // finding potential list of js chunk files
+    const chunkScriptsUri = [];
+    for (let key in manifest) {
+      if (key.endsWith('.chunk.js') && manifest.hasOwnProperty(key)) {
+        // finding their paths on the disk
+        let chunkScriptUri = vscode.Uri.file(
+          path.join(this.config.extensionPath, 'build', manifest[key])
+        ).with({
+          scheme: 'vscode-resource'
+        });
+        // push the chunk Uri to the list of chunks
+        chunkScriptsUri.push(chunkScriptUri);
+      }
+    }
 
     const runtimescriptPathOnDisk = vscode.Uri.file(
       path.join(this.config.extensionPath, 'build', runtimeScript)
     );
     const runtimescriptUri = runtimescriptPathOnDisk.with({
-      scheme: 'vscode-resource'
-    });
-    const chunkScriptPathOnDisk = vscode.Uri.file(
-      path.join(this.config.extensionPath, 'build', chunkScript)
-    );
-    const chunkScriptUri = chunkScriptPathOnDisk.with({
       scheme: 'vscode-resource'
     });
     const mainScriptPathOnDisk = vscode.Uri.file(
@@ -339,7 +347,7 @@ class BrowserViewWindow extends EventEmitter.EventEmitter2 {
 			<body>
 				<div id="root"></div>
 				<script src="${runtimescriptUri}"></script>
-				<script src="${chunkScriptUri}"></script>
+				${chunkScriptsUri.map((item) => `<script src="${item}"></script>`)}
 				<script src="${mainScriptUri}"></script>
 			</body>
 			</html>`;


### PR DESCRIPTION
Hi,

I've experienced an issue caused by generating the main HTML web view using the `asset-manifest.json` file contents. As you know chunk scripts entries in the manifest file are generated with a random string as their Keys. So, I think after changing the project source code or components a bit, create-react-app build command will generate different random keys and as a result (As I experienced) the correct chunk script file/files cannot be loaded into the HTML string.

On the other hand, chunk files can be more than one. Nevertheless, in my opinion, a vs code extension doesn't need to have chunked scripts at all. (So, we can also disable code splitting with some piece of hacks)

Generally, that could be a potential solution to iterate through the manifest entries to find the files which are ended with `.chunk.js` and generate a script tag for each of them. At least, I solved my problem this way.