### PR TITLE
Support for PNG/JPEG rendering via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Make sure you have Google Chrome installed on your computer.
 - Attach Chrome DevTools via `chrome://inspect`
 - Option to set the default startUrl via `browser-preview.startUrl`
 - Option to set the path to the chrome exectuable via `browser-preview.chromeExecutable`
+- Option to set the type of rendering via `browser-preview.format` with the support for `jpeg` (default one) and `png` formats
 
 ## Launch and Debugging
 

--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import BrowserPage from './browserPage';
 import * as whichChrome from 'which-chrome';
 import * as vscode from 'vscode';
+import { ExtensionConfiguration } from './extensionConfiguration';
 
 const puppeteer = require('puppeteer-core');
 const getPort = require('get-port');
@@ -11,11 +12,9 @@ const getPort = require('get-port');
 export default class Browser extends EventEmitter {
   private browser: any;
   public remoteDebugPort: number = 0;
-  private config: any;
 
-  constructor(config: object) {
+  constructor(private config: ExtensionConfiguration) {
     super();
-    this.config = config || {};
   }
 
   private async launchBrowser() {

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -5,6 +5,7 @@ import Browser from './browser';
 import BrowserPage from './browserPage';
 import TargetTreeProvider from './targetTreeProvider';
 import * as EventEmitter from 'eventemitter2';
+import { ExtensionConfiguration } from './extensionConfiguration';
 
 export function activate(context: vscode.ExtensionContext) {
   const windowManager = new BrowserViewWindowManager(context.extensionPath);
@@ -103,16 +104,15 @@ export function activate(context: vscode.ExtensionContext) {
 class BrowserViewWindowManager extends EventEmitter.EventEmitter2 {
   private openWindows: Set<BrowserViewWindow>;
   private browser: any;
-  private config: any;
+  private config: ExtensionConfiguration;
 
   constructor(extensionPath: string) {
     super();
     this.openWindows = new Set();
     this.config = {
       extensionPath: extensionPath,
-      chromeExecutable: null,
       startUrl: 'http://code.visualstudio.com',
-      isVerboseMode: false
+      format: 'jpeg'
     };
     this.refreshSettings();
   }
@@ -123,19 +123,24 @@ class BrowserViewWindowManager extends EventEmitter.EventEmitter2 {
     );
 
     if (extensionSettings) {
-      let chromeExecutable = extensionSettings.get('chromeExecutable');
+      let chromeExecutable = extensionSettings.get<string>('chromeExecutable');
       if (chromeExecutable !== undefined) {
         this.config.chromeExecutable = chromeExecutable;
       }
 
-      let startUrl = extensionSettings.get('startUrl');
+      let startUrl = extensionSettings.get<string>('startUrl');
       if (startUrl !== undefined) {
         this.config.startUrl = startUrl;
       }
 
-      let isVerboseMode = extensionSettings.get('verbose');
+      let isVerboseMode = extensionSettings.get<boolean>('verbose');
       if (isVerboseMode !== undefined) {
         this.config.isVerboseMode = isVerboseMode;
+      }
+
+      let format = extensionSettings.get<string>('format');
+      if (format !== undefined) {
+        this.config.format = format.includes('png') ? 'png' : 'jpeg';
       }
     }
   }
@@ -185,9 +190,9 @@ class BrowserViewWindow extends EventEmitter.EventEmitter2 {
 
   private browserPage: BrowserPage | null;
   private browser: Browser;
-  public config: any;
+  public config: ExtensionConfiguration;
 
-  constructor(config: any, browser: Browser) {
+  constructor(config: ExtensionConfiguration, browser: Browser) {
     super();
     this.config = config;
     this._panel = null;

--- a/ext-src/extensionConfiguration.ts
+++ b/ext-src/extensionConfiguration.ts
@@ -1,0 +1,7 @@
+export interface ExtensionConfiguration {
+  chromeExecutable?: string;
+  extensionPath: string;
+  format?: 'jpeg' | 'png';
+  isVerboseMode?: boolean;
+  startUrl?: string;
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
           "default": "",
           "description": "Toggles verbose logging",
           "type": "boolean"
+        },
+        "browser-preview.format": {
+          "default": "jpeg",
+          "description": "The type of image used in rendering preview. Supported values are: `jpeg` (default) and `png`",
+          "type": "string"
         }
       }
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,10 @@ import './App.css';
 import Toolbar from './components/toolbar/toolbar';
 import Viewport from './components/viewport/viewport';
 import Connection from './connection';
+import { ExtensionConfiguration } from '../ext-src/extensionConfiguration';
 
 interface IState {
+  format: 'jpeg' | 'png';
   frame: object | null;
   url: string;
   isVerboseMode: boolean;
@@ -21,13 +23,6 @@ interface IState {
   };
 }
 
-interface ExtensionConfigurationPayload {
-  startUrl?: string;
-  isVerboseMode?: boolean;
-  chromeExecutable?: string;
-  extensionPath?: string;
-}
-
 class App extends React.Component<any, IState> {
   private connection: Connection;
 
@@ -35,6 +30,7 @@ class App extends React.Component<any, IState> {
     super(props);
     this.state = {
       frame: null,
+      format: 'jpeg',
       url: 'about:blank',
       isVerboseMode: false,
       history: {
@@ -113,14 +109,15 @@ class App extends React.Component<any, IState> {
 
     this.connection.on(
       'extension.appConfiguration',
-      (payload: ExtensionConfigurationPayload) => {
+      (payload: ExtensionConfiguration) => {
         if (!payload) {
           return;
         }
 
         this.setState({
           isVerboseMode: payload.isVerboseMode ? payload.isVerboseMode : false,
-          url: payload.startUrl ? payload.startUrl : 'about:blank'
+          url: payload.startUrl ? payload.startUrl : 'about:blank',
+          format: payload.format ? payload.format : 'jpeg'
         });
 
         if (payload.startUrl) {
@@ -170,7 +167,7 @@ class App extends React.Component<any, IState> {
 
   public startCasting() {
     this.connection.send('Page.startScreencast', {
-      format: 'jpeg',
+      format: this.state.format,
       maxWidth: Math.floor(
         this.state.viewportMetadata.width * window.devicePixelRatio
       ),


### PR DESCRIPTION
This is a take to allow changing the rendering engine on the fly based on user configuration as discussed in: #14 

- move the configuration settings into type contract shared
by extension and rendering client
- add entry for 'format' settings
- remove duplicate contract code

Thanks!

<img width="895" alt="screenshot 2019-01-31 at 23 08 09" src="https://user-images.githubusercontent.com/14539/52090042-7d68c200-25b0-11e9-9e4e-4e03322a704a.png">
