### PR TITLE
Specify host when getting remote debugging port

### DIFF
--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -28,7 +28,7 @@ export default class Browser extends EventEmitter {
     }
 
     // Detect remote debugging port
-    this.remoteDebugPort = await getPort({ port: 9222 });
+    this.remoteDebugPort = await getPort({ port: 9222, host: '127.0.0.1' });
     chromeArgs.push(`--remote-debugging-port=${this.remoteDebugPort}`);
 
     if (!chromePath) {


### PR DESCRIPTION
By default, Chrome only binds to `127.0.0.1` when specifying a remote debugging port, but `get-port` (as a result of the [default behavior of node.js][1]) checks on the unspecified IPv6 or IPv4 address when determining if a port is in use or not.

Since they are different addresses, `get-port` won't detect another Chrome or node.js process that has already been bound to port 9222. This updates the usage of `get-port` to specify `127.0.0.1` when getting a remote debugging port.

[1]: https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback