### PR TITLE
new `browser-preview.openActiveFile`

### DIFF
--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -15,6 +15,20 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('browser-preview.openPreview', (url?) => {
       windowManager.create(url);
+    }),
+
+    vscode.commands.registerCommand('browser-preview.openActiveFile', () => {
+      const activeEditor = vscode.window.activeTextEditor;
+      if (!activeEditor) {
+        return; // no active editor: ignore the command
+      }
+
+      // get active url
+      const filename = activeEditor.document.fileName;
+
+      if (filename) {
+        windowManager.create(`file://${filename}`);
+      }
     })
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-browser-preview",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "activationEvents": [
     "onView:targetTree",
     "onCommand:browser-preview.openPreview",
+    "onCommand:browser-preview.openActiveFile",
     "onDebugInitialConfigurations",
     "onDebug",
     "onFileSystem:vsls",
@@ -68,6 +69,11 @@
         "category": "Browser Preview",
         "command": "browser-preview.openSharedBrowser",
         "title": "Open Shared Browser"
+      },
+      {
+        "category": "Browser Preview",
+        "command": "browser-preview.openActiveFile",
+        "title": "Open Active File in Preview"
       }
     ],
     "debuggers": [


### PR DESCRIPTION
As discussed in #71 I added a new command that that opens the active file as file:/ in a new browser preview.