### PR TITLE
Fix base64 header, fixes #89

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,6 +218,7 @@ class App extends React.Component<any, IState> {
           isInspectEnabled={this.state.isInspectEnabled}
           isDeviceEmulationEnabled={this.state.isDeviceEmulationEnabled}
           frame={this.state.frame}
+          format={this.state.format}
           url={this.state.url}
           onViewportChanged={this.onViewportChanged}
           ref={(c) => {

--- a/src/components/screencast/screencast.tsx
+++ b/src/components/screencast/screencast.tsx
@@ -183,6 +183,7 @@ class Screencast extends React.Component<any, any> {
       // }
 
       const highlightInfo = this.props.highlightInfo ? this.scaleBoxModelToViewport(this.props.highlightInfo) : null;
+      const format = this.props.format === 'jpeg' ? 'jpg' : 'png';
 
       this.setState({
         highlightInfo: highlightInfo,
@@ -191,7 +192,7 @@ class Screencast extends React.Component<any, any> {
         scrollOffsetY: metadata.scrollOffsetY
       });
 
-      imageElement.src = 'data:image/jpg;base64,' + screencastFrame.base64Data;
+      imageElement.src = 'data:image/' + format + ';base64,' + screencastFrame.base64Data;
     }
   }
 

--- a/src/components/screencast/screencast.tsx
+++ b/src/components/screencast/screencast.tsx
@@ -183,7 +183,7 @@ class Screencast extends React.Component<any, any> {
       // }
 
       const highlightInfo = this.props.highlightInfo ? this.scaleBoxModelToViewport(this.props.highlightInfo) : null;
-      const format = this.props.format === 'jpeg' ? 'jpg' : 'png';
+      const format = this.props.format;
 
       this.setState({
         highlightInfo: highlightInfo,

--- a/src/components/viewport/viewport.tsx
+++ b/src/components/viewport/viewport.tsx
@@ -75,6 +75,7 @@ class Viewport extends React.Component<any, any> {
         height={height}
         width={width}
         frame={this.props.frame}
+        format={this.props.format}
         viewportMetadata={this.viewportMetadata}
         isInspectEnabled={this.props.isInspectEnabled}
         onInspectElement={this.handleInspectElement}


### PR DESCRIPTION
Image tag base64 header was always set to data:image/jpg, even if format was set to png.

Chrome didn't seem to care so this worked but was incorrect.