### PR TITLE
FIXED: two little bugs that caused lots of "uncaught promise" errors

### DIFF
--- a/ext-src/BrowserViewWindow.ts
+++ b/ext-src/BrowserViewWindow.ts
@@ -131,7 +131,11 @@ export class BrowserViewWindow extends EventEmitter.EventEmitter2 {
 
         if (this.browserPage) {
           try {
-            this.browserPage.send(msg.type, msg.params, msg.callbackId);
+            // not sure about this one but this throws later with unhandled
+            // 'extension.appStateChanged' message
+            if (msg.type !== 'extension.appStateChanged') {
+              this.browserPage.send(msg.type, msg.params, msg.callbackId);
+            }
             this.emit(msg.type, msg.params);
           } catch (err) {
             vscode.window.showErrorMessage(err);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -294,8 +294,6 @@ class App extends React.Component<any, IState> {
           y: data.params.position.y
         });
 
-        console.log('highlightNodeInfo', highlightNodeInfo);
-
         if (highlightNodeInfo) {
           // let highlightBoxModel: any = await this.connection.send('DOM.getBoxModel', {
           //   backendNodeId: highlightNodeInfo.backendNodeId

--- a/src/components/screencast/screencast.tsx
+++ b/src/components/screencast/screencast.tsx
@@ -102,6 +102,9 @@ class Screencast extends React.Component<any, any> {
 
     if (!this.canvasContext) {
       return;
+    } else {
+      // disable smoothing when calling drawImage
+      this.canvasContext['imageSmoothingEnabled'] = false;
     }
 
     let devicePixelRatio = window.devicePixelRatio || 1;
@@ -236,10 +239,14 @@ class Screencast extends React.Component<any, any> {
         position: position
       });
     } else {
-      const position = this.convertIntoScreenSpace(event, this.state);
-      this.props.onInspectHighlightRequested({
-        position: position
-      });
+      // only calls InspectHighlightRequested if inspect is enabled: fixes
+      // uncaught rejected promise later because position.x/y is NaN
+      if (this.props.isInspectEnabled) {
+        const position = this.convertIntoScreenSpace(event, this.state);
+        this.props.onInspectHighlightRequested({
+          position: position
+        });
+      }
 
       this.dispatchMouseEvent(event.nativeEvent);
     }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -57,7 +57,7 @@ export default class Connection extends EventEmitter2 {
         if (callback) {
           this.callbacks.delete(object.callbackId);
           if (object.error) {
-            callback.reject(callback.error, callback.method, object);
+            callback.reject(object.error, callback.method, object);
           } else {
             callback.resolve(object.result);
           }


### PR DESCRIPTION
Opening the webview console would show lots of errors which were due to promise rejections not being handled.

I tracked these problems to this:

 - `onInspectHighlightRequested` was called with no x/y positions (position.x/y were set to NaN): I guess it shouldn't be called if inspect is disabled
 - sending 'extension.appStateChanged' seems to throw an error because this msg type is not handled (I am not sure about this one)

I also set the canvas'context `imageSmoothingEnabled` property to false but this won't fix the blurry effect until #92 is not resolved.