### PR TITLE
Fix retrieval of debug port

### DIFF
--- a/ext-src/debugProvider.ts
+++ b/ext-src/debugProvider.ts
@@ -17,7 +17,7 @@ export default class DebugProvider {
   }
 
   getProvider(): vscode.DebugConfigurationProvider {
-    let debugPort = this.windowManager.getDebugPort();
+    let manager = this.windowManager;
 
     return {
       provideDebugConfigurations(
@@ -59,7 +59,7 @@ export default class DebugProvider {
         if (config && config.type === 'browser-preview') {
           if (config.request && config.request === `attach`) {
             debugConfig.name = `Browser Preview: Attach`;
-            debugConfig.port = debugPort;
+            debugConfig.port = debugConfig.port as number;
 
             vscode.debug.startDebugging(folder, debugConfig);
           } else if (config.request && config.request === `launch`) {
@@ -71,7 +71,7 @@ export default class DebugProvider {
 
             launch.then(() => {
               setTimeout(() => {
-                debugConfig.port = debugPort;
+                debugConfig.port = manager.getDebugPort();
                 vscode.debug.startDebugging(folder, debugConfig);
               }, 1000);
             });

--- a/package.json
+++ b/package.json
@@ -147,7 +147,15 @@
             }
           },
           "attach": {
+            "required": [
+              "port"
+            ],
             "properties": {
+              "port": {
+                "type": "number",
+                "description": "Port to use for Chrome remote debugging",
+                "default": 9222
+              },
               "urlFilter": {
                 "type": "string",
                 "description": "Will search for a page with this url and attach to it, if found. Can have * wildcards.",


### PR DESCRIPTION
Fixes #68

- For launch tasks, wait until the browser has successfully opened before getting the remote debug port
- For attach tasks, add a port config property and use that to mirror how normal Chrome debug attach tasks are defined