### PR TITLE
Improve attach debug port resolution

### DIFF
--- a/ext-src/debugProvider.ts
+++ b/ext-src/debugProvider.ts
@@ -53,15 +53,20 @@ export default class DebugProvider {
           sourceMapPathOverrides: config.sourceMapPathOverrides,
           urlFilter: '',
           url: '',
-          port: 9222
+          port: null
         };
 
         if (config && config.type === 'browser-preview') {
           if (config.request && config.request === `attach`) {
             debugConfig.name = `Browser Preview: Attach`;
-            debugConfig.port = debugConfig.port as number;
-
-            vscode.debug.startDebugging(folder, debugConfig);
+            debugConfig.port = manager.getDebugPort();
+            if (debugConfig.port === null) {
+              vscode.window.showErrorMessage(
+                'No Browser Preview window was found. Open a Browser Preview window or use the "launch" request type.'
+              );
+            } else {
+              vscode.debug.startDebugging(folder, debugConfig);
+            }
           } else if (config.request && config.request === `launch`) {
             debugConfig.name = `Browser Preview: Launch`;
             debugConfig.urlFilter = config.url;

--- a/package.json
+++ b/package.json
@@ -147,15 +147,7 @@
             }
           },
           "attach": {
-            "required": [
-              "port"
-            ],
             "properties": {
-              "port": {
-                "type": "number",
-                "description": "Port to use for Chrome remote debugging",
-                "default": 9222
-              },
               "urlFilter": {
                 "type": "string",
                 "description": "Will search for a page with this url and attach to it, if found. Can have * wildcards.",


### PR DESCRIPTION
A follow up to #97.

I'm not sure why I thought it was necessary to explicitly specify a port number for attach debug types since the window manager should be able to provide one if a Browser Preview window is open.

I've reverted the additional debug configuration property, and now check to see if the window manager was able to resolve the port. If not, then an error message is displayed prompting the user to open a Browser Preview window or use the "launch" debug request type.