### PR TITLE
Support `preLaunchTask`

### DIFF
--- a/ext-src/BrowserViewWindowManager.ts
+++ b/ext-src/BrowserViewWindowManager.ts
@@ -57,13 +57,19 @@ export class BrowserViewWindowManager extends EventEmitter.EventEmitter2 {
     return 1;
   }
 
-  public async create(startUrl?: string, id?: string) {
+  public async launch() {
     this.refreshSettings();
-    let config = { ...this.defaultConfig };
 
     if (!this.browser) {
-      this.browser = new Browser(config);
+      this.browser = new Browser({ ...this.defaultConfig });
     }
+
+    await this.browser.launchBrowser();
+  }
+
+  public async create(startUrl?: string, id?: string) {
+    await this.launch();
+    let config = { ...this.defaultConfig };
 
     let lastColumnNumber = this.getLastColumnNumber();
     if (lastColumnNumber) {

--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -18,7 +18,11 @@ export default class Browser extends EventEmitter {
     super();
   }
 
-  private async launchBrowser() {
+  public async launchBrowser() {
+    if (this.browser) {
+      return;
+    }
+
     let chromePath = whichChrome.Chrome || whichChrome.Chromium;
     let chromeArgs = [];
     let platform = os.platform();
@@ -48,9 +52,7 @@ export default class Browser extends EventEmitter {
   }
 
   public async newPage(): Promise<BrowserPage> {
-    if (!this.browser) {
-      await this.launchBrowser();
-    }
+    await this.launchBrowser();
 
     var page = new BrowserPage(this.browser);
     await page.launch();


### PR DESCRIPTION
- Allow launching the headless Chrome instance separately from opening a browser page/tab
- Update config resolution to return the provided config and only modify the properties as needed to support any configuration property from the Chrome debugger
- For launch debug types, use a debug adapter tracker to open the browser tab just before starting the debug session to allow `preLaunchTask` to execute before attempting to load the URL