### PR TITLE
Rotate button is added to the device emulation toolbar

### DIFF
--- a/src/components/device-settings/device-settings.css
+++ b/src/components/device-settings/device-settings.css
@@ -15,6 +15,12 @@ select {
   padding: 5px; /* If you add too much padding here, the options won't show in IE */
 }
 
+.device-settings > button.rotate-device {
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTYuNDggMi41MmMzLjI3IDEuNTUgNS42MSA0LjcyIDUuOTcgOC40OGgxLjVDMjMuNDQgNC44NCAxOC4yOSAwIDEyIDBsLS42Ni4wMyAzLjgxIDMuODEgMS4zMy0xLjMyem0tNi4yNS0uNzdjLS41OS0uNTktMS41NC0uNTktMi4xMiAwTDEuNzUgOC4xMWMtLjU5LjU5LS41OSAxLjU0IDAgMi4xMmwxMi4wMiAxMi4wMmMuNTkuNTkgMS41NC41OSAyLjEyIDBsNi4zNi02LjM2Yy41OS0uNTkuNTktMS41NCAwLTIuMTJMMTAuMjMgMS43NXptNC42IDE5LjQ0TDIuODEgOS4xN2w2LjM2LTYuMzYgMTIuMDIgMTIuMDItNi4zNiA2LjM2em0tNy4zMS4yOUM0LjI1IDE5Ljk0IDEuOTEgMTYuNzYgMS41NSAxM0guMDVDLjU2IDE5LjE2IDUuNzEgMjQgMTIgMjRsLjY2LS4wMy0zLjgxLTMuODEtMS4zMyAxLjMyeiIvPjwvc3ZnPg==);
+  background-size: 14px 14px;
+  vertical-align: middle;
+}
+
 .viewport-size-input {
   max-width: 45px;
   text-align: center;

--- a/src/components/device-settings/device-settings.tsx
+++ b/src/components/device-settings/device-settings.tsx
@@ -13,6 +13,7 @@ class DeviceSettings extends React.Component<any, any> {
     this.handleWidthChange = this.handleWidthChange.bind(this);
     this.handleHeightChange = this.handleHeightChange.bind(this);
     this.handleDeviceChange = this.handleDeviceChange.bind(this);
+    this.handleRotateDevice = this.handleRotateDevice.bind(this);
 
     this.emulatedDevices = [
       { name: 'Responsive', userAgent: '', viewport: [] },
@@ -96,8 +97,24 @@ class DeviceSettings extends React.Component<any, any> {
             );
           })}
         </select>
+        <button
+          className="rotate-device"
+          onClick={this.handleRotateDevice}
+          disabled={this.props.viewportMetadata.emulatedDeviceId == 'Responsive' ? true : false}
+        />
       </div>
     );
+  }
+
+  private handleRotateDevice() {
+    let device = this.emulatedDevices.find((d: any) => d.name == this.props.viewportMetadata.emulatedDeviceId);
+    device.viewport.height = this.props.viewportMetadata.width;
+    device.viewport.width = this.props.viewportMetadata.height;
+
+    this.props.onDeviceChange(device);
+
+    // dispatch the orientationchange event
+    window.dispatchEvent(new Event('onorientationchange'));
   }
 
   private handleDeviceChange(e: React.ChangeEvent<HTMLSelectElement>) {


### PR DESCRIPTION
According to #109 ...

Currently, the rotate button would be enabled if you chose one of the predefined devices (Not in the responsive mode). Because the `Responsive` mode is tightly coupled with lots of higher order logic in the Viewport and the App components and I haven't had enough time to amend all of them appropriately right now. (Maybe in the next days 😃)