### PR TITLE
Updating activation events for Live Share "presence"

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "onCommand:liveshare.startFromActivityBar",
     "onCommand:liveshare.startReadOnly",
     "onCommand:liveshare.startReadOnlyFromActivityBar",
-    "onCommand:liveshare.startReadOnlyFromSessionExplorer"
+    "onCommand:liveshare.startReadOnlyFromSessionExplorer",
+    "onCommand:liveshare.inviteUserJoin",
+    "onCommand:liveshare.inviteUserJoinByEmail"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
This PR simply updates the extension's activation events so that it correctly activates when a user starts a Live Share session by [directly inviting someone](https://docs.microsoft.com/en-us/visualstudio/liveshare/reference/insiders#direct-user-invitations) (as opposed to just clicking the `Live Share` button).

