### PR TITLE
Added option to ignore HTTPS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Make sure you have Google Chrome installed on your computer.
 - Option to set the type of rendering via `browser-preview.format` with the support for `jpeg` (default one) and `png` formats
 
 ## How to change the default start url / start page?
+
 Go to your settings, search for "browser preview" and set `browser-preview.startUrl` to your desired url.
 
 ![](assets/settings.png)
@@ -43,20 +44,20 @@ You can enable in-editor debugging of Browser Preview by installing [Debugger fo
 
 ```json
 {
-    "version": "0.1.0",
-    "configurations": [
-        {
-            "type": "browser-preview",
-            "request": "attach",
-            "name": "Browser Preview: Attach"
-        },
-        {
-            "type": "browser-preview",
-            "request": "launch",
-            "name": "Browser Preview: Launch",
-            "url": "http://localhost:3000"
-        }
-    ]
+  "version": "0.1.0",
+  "configurations": [
+    {
+      "type": "browser-preview",
+      "request": "attach",
+      "name": "Browser Preview: Attach"
+    },
+    {
+      "type": "browser-preview",
+      "request": "launch",
+      "name": "Browser Preview: Launch",
+      "url": "http://localhost:3000"
+    }
+  ]
 }
 ```
 
@@ -75,4 +76,5 @@ Browser Preview has the following settings:
 "browser-preview.verbose": false // Enable verbose logging of messages sent between VS Code and Chrome instance
 "browser-preview.chromeExecutable": // The full path to the executable, including the complete filename of the executable
 "browser-preview.format": // Option to set the type of rendering with the support for `jpeg` (default one) and `png` formats
+"browser-preview.ignoreHttpsErrors": false // Ignore HTTPS errors if you are using self-signed SSL certificates
 ```

--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -48,9 +48,12 @@ export default class Browser extends EventEmitter {
       chromeArgs.push('--no-sandbox');
     }
 
+    let extensionSettings = vscode.workspace.getConfiguration('browser-preview');
+    let ignoreHTTPSErrors = extensionSettings.get<boolean>('ignoreHttpsErrors');
     this.browser = await puppeteer.launch({
       executablePath: chromePath,
-      args: chromeArgs
+      args: chromeArgs,
+      ignoreHTTPSErrors
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
           "default": "jpeg",
           "description": "The type of image used in rendering preview. Supported values are: `jpeg` (default) and `png`",
           "type": "string"
+        },
+        "browser-preview.ignoreHttpsErrors": {
+          "default": "",
+          "description": "Ignore HTTPS errors if you are using self-signed SSL certificates",
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
Name: `"browser-preview.ignoreHttpsErrors"`

Its value will be passed as `ignoreHTTPSErrors` to `puppeteer.launch([options])`.
[(Docs)](https://github.com/puppeteer/puppeteer/blob/v5.2.1/docs/api.md#puppeteerlaunchoptions)

You may need to reopen the browser tab for changes to take effect.
You can try it with [this](https://self-signed.badssl.com/) link.

Closes #142 