### PR TITLE
Fix a bug in safari where browser image is not displayed

### DIFF
--- a/src/components/screencast/screencast.css
+++ b/src/components/screencast/screencast.css
@@ -4,6 +4,11 @@
   image-rendering: pixelated; /* Disables interpolation. See https://stackoverflow.com/questions/7615009/disable-interpolation-when-scaling-a-canvas */
 }
 
-.img-hidden {
-  display: none;
+.img-pointer-events-passthrough {
+  pointer-events: none;
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
 }

--- a/src/components/screencast/screencast.css
+++ b/src/components/screencast/screencast.css
@@ -8,7 +8,5 @@
   pointer-events: none;
   position: absolute;
   top: 0px;
-  bottom: 0px;
   left: 0px;
-  right: 0px;
 }

--- a/src/components/screencast/screencast.tsx
+++ b/src/components/screencast/screencast.tsx
@@ -75,7 +75,7 @@ class Screencast extends React.Component<any, any> {
 
     return (
       <>
-        <img ref={this.imageRef} className="img-hidden" />
+        <img ref={this.imageRef} className="img-pointer-events-passthrough" />
         <canvas
           className="screencast"
           style={canvasStyle}


### PR DESCRIPTION
This PR addresses an issue where display: none css in Safari hides the browser image.

The fix here changes display none to instead passthrough pointer events and position the image absolutely, allowing the canvas element to sit directly behind it.

Closes #178