### PR TITLE
#31 enable audio by ignoring flag in chromium default args

### DIFF
--- a/ext-src/browser.ts
+++ b/ext-src/browser.ts
@@ -54,6 +54,7 @@ export default class Browser extends EventEmitter {
     this.browser = await puppeteer.launch({
       executablePath: chromePath,
       args: chromeArgs,
+      ignoreDefaultArgs: ['--mute-audio'],
       ignoreHTTPSErrors
     });
   }


### PR DESCRIPTION
Audio in headless chromiums was muted back in 2017, in this precise commit: https://github.com/puppeteer/puppeteer/commit/1ca784901743792726e3896ed4d4809a66d6a213

Also, this exact solution seems to be referenced in the [API Documentation](https://github.com/puppeteer/puppeteer/blob/v10.1.0/docs/api.md#:~:text=You%20can%20use,ignoreDefaultArgs%3A%20%5B%27--mute-audio%27%5D%2C%0A%7D%29%3B), albeit with no useful context.

This PR would fix #31 and #140, as far as I'm concerned.